### PR TITLE
fix linear algebra (typo and function name deprecated)

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,7 +743,7 @@ b = deepcopy(a)</code>
            <p>Julia has built-in support for <a href="https://docs.julialang.org/en/v1.0.0/stdlib/LinearAlgebra/"
                target="_blank">matrix
                 decompositions</a>.</p>
-            <p> Julia tries to infer whether matrices are of a special type (symmetric, hermitian, etc.), but sometimes fails. To aid Julia in dispatching the optimal algorithms, special matrices can be declared ot have a structure with functions like <code>Symmetric</code>, <code>Hermitian</code>, <code>UpperTriangular</code>, <code>LowerTriangular</code>, <code>Diagonal</code>, and more.
+            <p> Julia tries to infer whether matrices are of a special type (symmetric, hermitian, etc.), but sometimes fails. To aid Julia in dispatching the optimal algorithms, special matrices can be declared to have a structure with functions like <code>Symmetric</code>, <code>Hermitian</code>, <code>UpperTriangular</code>, <code>LowerTriangular</code>, <code>Diagonal</code>, and more.
          </div>
        </li>
        <li>

--- a/index.html
+++ b/index.html
@@ -702,7 +702,7 @@ b = deepcopy(a)</code>
                </tr>
                <tr>
                  <td>Conjugate matrix transposition</td>
-                 <td><code>M'</code> or <code>ctranspose(M)</code></td>
+                 <td><code>M'</code> or <code>adjoint(M)</code></td>
                </tr>
                <tr>
                  <td>Matrix trace</td>


### PR DESCRIPTION
Since Julia 1.0 ctranspose has been deprecated. According to Julia 0.7, adjoint should be used. 

Also minor mispelling issue (ot should be to)