### PR TITLE
A typo fixed in _includes/[br,en]/Arrays.md

### DIFF
--- a/_includes/br/Arrays.md
+++ b/_includes/br/Arrays.md
@@ -5,7 +5,7 @@
 | Acesso e atribuição	                          | `arr = Any[1,2]`<br>`arr[1] = "Some text"`                                           |
 | Comparação                                      | `a = [1:10;]`<br>`b = a      # b points to a`<br>`a[1] = -99`<br>`a == b     # true` |
 | Copiar elementos (não endereços)                | `b = copy(a)`<br>`b = deepcopy(a)`                                                   |
-| Selecionar a subarray de m para n               | `arr[n:m]`                                                                           |
+| Selecionar a subarray de m para n               | `arr[m:n]`                                                                           |
 | n-elemento array com 0.0s                       | `zeros(n)`                                                                           |
 | n-elemento array com 1.0s                       | `ones(n)`                                                                            |
 | n-elemento array com #undefs                    | `Vector{Type}(undef,n)`                                                              |

--- a/_includes/en/Arrays.md
+++ b/_includes/en/Arrays.md
@@ -5,7 +5,7 @@
 | Access and assignment	                          | `arr = Any[1,2]`<br>`arr[1] = "Some text"`                                           |
 | Comparison                                      | `a = [1:10;]`<br>`b = a      # b points to a`<br>`a[1] = -99`<br>`a == b     # true` |
 | Copy elements (not address)                     | `b = copy(a)`<br>`b = deepcopy(a)`                                                   |
-| Select subarray from m to n                     | `arr[n:m]`                                                                           |
+| Select subarray from m to n                     | `arr[m:n]`                                                                           |
 | n-element array with 0.0s                       | `zeros(n)`                                                                           |
 | n-element array with 1.0s                       | `ones(n)`                                                                            |
 | n-element array with #undefs                    | `Vector{Type}(undef,n)`                                                              |


### PR DESCRIPTION
I just fixed a small typo in ```Arrays.md``` for both ```en``` and ```br``` versions. Thanks!