### PR TITLE
[zh-cn] Translation part 5

### DIFF
--- a/_includes/zh-cn/Macros.md
+++ b/_includes/zh-cn/Macros.md
@@ -1,15 +1,14 @@
-Macros allow generated code (i.e. expressions) to be included in a
-program.
+宏允许你在程序中自动生成代码（如：表达式）。
 
-|                 |                                                            |
-| --------------- | ---------------------------------------------------------- |
-| Definition      | `macro macroname(expr)`<br>`    # do stuff`<br>`end`       |
-| Usage           | `macroname(ex1, ex2, ...)` or `@macroname ex1, ex2, ...`   |
-| Built-in macros | `@test           # equal (exact)`<br>`@test_approx_eq # equal (modulo numerical errors)`<br>`@test x ≈ y    # isapprox(x, y)`<br>`@assert         # assert (unit test)`<br>`@which          # types used`<br>`@time           # time and memory statistics`<br>`@elapsed        # time elapsed`<br>`@allocated      # memory allocated`<br>`@profile        # profile`<br>`@spawn          # run at some worker`<br>`@spawnat        # run at specified worker`<br>`@async          # asynchronous task`<br>`@distributed    # parallel for loop`<br>`@everywhere     # make available to workers` |
+|         |                                                            |
+| ------- | ---------------------------------------------------------- |
+| 定义    | `macro macroname(expr)`<br>`    # 做点啥`<br>`end`          |
+| 使用    | `macroname(ex1, ex2, ...)` 或 `@macroname ex1, ex2, ...`    |
+| 内置的宏 | `@test           # 精确相等`<br>`@test x ≈ y    # 近似相等 isapprox(x, y)`<br>`@assert         # assert (单元测试)`<br>`@which          # 查看对特定参数使用的方法/查找函数所在的模块`<br>`@time           # 运行时间与内存分配统计`<br>`@elapsed        # 返回执行用时`<br>`@allocated      # 查看内存分配`<br>`@async          # 异步任务` |
 
 
-Rules for creating *hygienic* macros:
+创建 *卫生宏* (hygienic macros)的规则：
 
-- Declare variables inside macro with `local` .
-- Do not call `eval` inside macro.
-- Escape interpolated expressions to avoid expansion: `$(esc(expr))`
+- 在宏的内部只通过 `local` 声明本地变量。
+- 在宏的内部不使用 `eval`。
+- 转义插值表达式以避免宏变大：`$(esc(expr))`

--- a/_includes/zh-cn/Numbers.md
+++ b/_includes/zh-cn/Numbers.md
@@ -1,16 +1,16 @@
-|                                    |                                                                    |
-| ---------------------------------- | ------------------------------------------------------------------ |
-| Integer types                      | `IntN` and `UIntN`, with `N ∈ {8, 16, 32, 64, 128}`, `BigInt`      |
-| Floating-point types               | `FloatN` with `N ∈ {16, 32, 64}`<br>`BigFloat`                     |
-| Minimum and maximum values by type | `typemin(Int8)`<br>`typemax(Int64)`                                |
-| Complex types                      | `Complex{T}`                                                       |
-| Imaginary unit                     | `im`                                                               |
-| Machine precision                  | `eps() # same as eps(Float64)`                                     |
-| Rounding                           | `round()       # floating-point`<br>`round(Int, x) # integer`      |
-| Type conversions                   | `convert(TypeName, val)  # attempt/error`<br>`typename(val)           # calls convert` |
-| Global constants                   | `pi # 3.1415...`<br>`π  # 3.1415...`<br>`im # real(im * im) == -1` |
-| More constants                     | `using Base.MathConstants`                                         |
+|                   |                                                                    |
+| ----------------- | ------------------------------------------------------------------ |
+| 整数类型           | `IntN` 和 `UIntN`, 且 `N ∈ {8, 16, 32, 64, 128}`, `BigInt`         |
+| 浮点类型           | `FloatN` 且 `N ∈ {16, 32, 64}`<br>`BigFloat`                       |
+| 类型的最大和最小值  | `typemin(Int8)`<br>`typemax(Int64)`                                |
+| 复数类型           | `Complex{T}`                                                       |
+| 虚数单位           | `im`                                                               |
+| 机器精度           | `eps() # 等价于 eps(Float64)`                                      |
+| 圆整               | `round()       # 浮点数圆整`<br>`round(Int, x) # 整数圆整`          |
+| 类型转换           | `convert(TypeName, val)  # 尝试进行转换/可能会报错`<br>`typename(val)           # 调用转换` |
+| 全局常量           | `pi # 3.1415...`<br>`π  # 3.1415...`<br>`im # real(im * im) == -1` |
+| 更多常量           | `using Base.MathConstants`                                         |
 
-Julia does not automatically check for numerical overflow. Use package
-[SaferIntegers](https://github.com/JeffreySarnoff/SaferIntegers.jl) for ints
-with overflow checking.
+Julia 不会自动检测数值溢出。
+使用 [SaferIntegers](https://github.com/JeffreySarnoff/SaferIntegers.jl)
+包可以得到带溢出检查的整数。

--- a/_includes/zh-cn/Parallel-Computing.md
+++ b/_includes/zh-cn/Parallel-Computing.md
@@ -1,27 +1,25 @@
-Parallel computing tools are available in the `Distributed` standard library.
+并行计算相关的工具可以在标准库 `Distributed` 里找到。
 
-|                                            |                                   |
-| ------------------------------------------ | --------------------------------- |
-| Launch REPL with N workers                 | `julia -p N`                      |
-| Number of available workers                | `nprocs()`                        |
-| Add N workers                              | `addprocs(N)`                     |
-| See all worker ids                         | `for pid in workers()`<br>`    println(pid)`<br>`end` |
-| Get id of executing worker                 | `myid()`                          |
-| Remove worker                              | `rmprocs(pid)`                    |
-| Run f with arguments args on pid           | `r = remotecall(f, pid, args...)`<br>`# or:`<br>`r = @spawnat pid f(args)`<br>`...`<br>`fetch(r)` |
-| Run f with arguments args on pid (more efficient) | `remotecall_fetch(f, pid, args...)` |
-| Run f with arguments args on any worker    | `r = @spawn f(args) ... fetch(r)` |
-| Run f with arguments args on all workers   | `r = [@spawnat w f(args) for w in workers()] ... fetch(r)` |
-| Make expr available to all workers         | `@everywhere expr`                |
-| Parallel for loop with <a class="tooltip" href="#">reducer<span>A reducer combines the results from different (independent) workers.</span></a> function red | `sum = @distributed (red) for i in 1:10^6`<br>`    # do parallelstuff`<br>`end` |
-| Apply f to all elements in collection coll | `pmap(f, coll)`                   |
+|                                            |                                 |
+| ------------------------------------------ | ------------------------------- |
+| 启动带 N 各 worker 的 REPL                  | `julia -p N`                    |
+| 可用的 worker 数量                          | `nprocs()`                      |
+| 添加 N 个 worker                            | `addprocs(N)`                   |
+| 查看所有 worker 的 pid                      | `for pid in workers()`<br>`    println(pid)`<br>`end` |
+| 获得正在执行的 worker 的 id                 | `myid()`                         |
+| 移除 worker                                | `rmprocs(pid)`                   |
+| 在特定 pid 的 worker 上运行 f(args)         | `r = remotecall(f, pid, args...)`<br>`# 或:`<br>`r = @spawnat pid f(args)`<br>`...`<br>`fetch(r)` |
+| 在特定 pid 的 worker 上运行 f(args) (更高效) | `remotecall_fetch(f, pid, args...)` |
+| 在任意 worker 上运行 f(args)                | `r = @spawn f(args) ... fetch(r)` |
+| 在所有 worker 上运行 f(args)                | `r = [@spawnat w f(args) for w in workers()] ... fetch(r)` |
+| 让表达式 expr 在所有 worker 上执行           | `@everywhere expr`              |
+| 并行化带<a class="tooltip" href="#">规约函数<span> 一个规约函数(reducer function)将不同独立 worker 的结果结合起来。 </span></a> red 的循环 | `sum = @distributed (red) for i in 1:10^6`<br>`    # 进行并行任务`<br>`end` |
+| 将 f 用用到集合 coll 中的所有元素上           | `pmap(f, coll)`                 |
 
-Workers are also known as concurrent/parallel processes.
+Worker 就是人们所说的并行/并发的进程。
 
-Modules with parallel processing capabilities are best split into a
-functions file that contains all the functions and variables needed by
-all workers, and a driver file that handles the processing of data. The
-driver file obviously has to import the functions file.
+需要并行化的模块，最好拆分成包含所有功能与变量的函数文件，和一个用于处理数据的驱动文件。
+很明显驱动文件需要导入函数文件。
 
-A non-trivial (word count) example of a reducer function is provided by
+一个有实际意义的规约函数的例子：单词计数 by 
 [Adam DeConinck](https://blog.ajdecon.org/parallel-word-count-with-julia-an-interesting).

--- a/_includes/zh-cn/Random-Numbers.md
+++ b/_includes/zh-cn/Random-Numbers.md
@@ -1,9 +1,9 @@
-Many random number functions require `using Random`.
+许多随机数函数都需要 `using Random`。
 
-|                                  |                                                               |
-| -------------------------------- | ------------------------------------------------------------- |
-| Set seed                         | `seed!(seed)`                                                 |
-| Random numbers                   | `rand()   # uniform [0,1)`<br>`randn()  # normal (-Inf, Inf)` |
-| Random from Other Distribution   | `using Distributions`<br>`my_dist = Bernoulli(0.2) # For example`<br>`rand(my_dist)` |
-| Random subsample elements from A with inclusion probability p | `randsubseq(A, p)`               |
-| Random permutation elements of A | `shuffle(A)`                                                  |
+|                               |                                                               |
+| ----------------------------- | ------------------------------------------------------------- |
+| 设置随机数种子                 | `seed!(seed)`                                                 |
+| 产生随机数                     | `rand()   # 均匀分布 [0,1)`<br>`randn()  # 正态分布 (-Inf, Inf)` |
+| 产生特定分布的随机数            | `using Distributions`<br>`my_dist = Bernoulli(0.2) # 举例`<br>`rand(my_dist)` |
+| 以包含概率 p 从 A 中随机二次取样 | `randsubseq(A, p)`                                            |
+| 随机重排 A 中的元素             | `shuffle(A)`                                                  |


### PR DESCRIPTION
- translated `Macros.md`, `Numbers.md`, `Parallel-Computing.md`, `Random-Numbers.md`
- `@test_approx_eq` is Deprecated, using `isapprox` instead
- `@profile` moves to `Profile` stdlib
- `@spawn` `@spawnat` `@distributed` `@everywhere` moves to `Distributed` stdlib