### PR TITLE
Clarify section

### DIFF
--- a/_includes/en/Modules.md
+++ b/_includes/en/Modules.md
@@ -4,10 +4,9 @@ Modules are separate global variable workspaces that group together similar func
 | --------------------- | ---------------------------------------------------- |
 | Definition            | `module PackageName`<br>`# add module definitions`<br>`# use export to make definitions accessible`<br>`end` |
 | Include `filename.jl` | `include("filename.jl")`                             |
-| Load                  | `using ModuleName        # all exported names`<br>`using ModuleName: x, y              # only x, y`<br>`using ModuleName.x, ModuleName.y:   # only x, y`<br>`import ModuleName       # only ModuleName`<br>`import ModuleName: x, y             # only x, y`<br>`import ModuleName.x, ModuleName.y   # only x, y` |
-| Exports               | `# Get an array of names exported by Module`<br>`names(ModuleName)`<br><br>`# include non-exports, deprecateds`<br>`# and compiler-generated names`<br>`names(ModuleName, all::Bool)`<br><br>`#also show namesexplicitely imported from other modules`<br>`names(ModuleName, all::Bool, imported::Bool)` |
+| Load                  | `using ModuleName        # all exported names`<br>`using ModuleName: x, y              # only x, y`<br>`import ModuleName       # only ModuleName`<br>`import ModuleName: x, y             # only x, y`<br>`import ModuleName.x, ModuleName.y   # only x, y` |
+| Exports               | `# Get an array of names exported by Module`<br>`names(ModuleName)`<br><br>`# include non-exports, deprecateds`<br>`# and compiler-generated names`<br>`names(ModuleName, all::Bool)`<br><br>`#also show names explicitly imported from other modules`<br>`names(ModuleName, all::Bool, imported::Bool)` |
 
-There is only one difference between `using` and `import` : with `using` you need to say
-`function Foo.bar(..` to extend module `Foo`'s function `bar` with a new method, but
-with `import Foo.bar`, you only need to say `function bar(...` and it automatically
-extends module `Foo`'s function `bar` .
+With `using Foo` you need to say `function Foo.bar(...` to extend module `Foo`'s
+function `bar` with a new method, but with `import Foo.bar`, you only need to say
+`function bar(...` and it automatically extends module `Foo`'s function `bar` .


### PR DESCRIPTION
Proposed changes:
* Remove `using ModuleName.x, ModuleName.y # only x, y` since this only works if `x` and `y` are modules, and in this case it works like a regular `using` by pulling all exported names in the scope.
* In the last sentence:
** Remove `There is only one difference between using and import` since that's not the *only* difference.
** Explicitly write `using Foo` and `import Foo.bar` since that's what we are comparing (as `using Foo.bar` is not possible).
* Fix typo: explicitely => explicitly