### PR TITLE
Replace LightGraphs.jl with Graphs.jl

### DIFF
--- a/_includes/br/Noteworthy-packages-and-projects.md
+++ b/_includes/br/Noteworthy-packages-and-projects.md
@@ -14,4 +14,4 @@ Julia\[Tópico\].
 |
 | Machine Learning científica | SciML (formerly DifferentialEquations.jl) 
 |
-| Pacotes muito usados       | `DataFrames    # regressão logistica/linear`<br>`Distributions # distribuições estatísticas`<br>`Flux          # Machine learning`<br>`Gadfly        # plotagem parecida com ggplot2`<br>`LightGraphs   # Análise de rede`<br>`TextAnalysis  # PNL` |
+| Pacotes muito usados       | `DataFrames    # regressão logistica/linear`<br>`Distributions # distribuições estatísticas`<br>`Flux          # Machine learning`<br>`Gadfly        # plotagem parecida com ggplot2`<br>`Graphs        # Análise de rede`<br>`TextAnalysis  # PNL` |

--- a/_includes/en/Noteworthy-packages-and-projects.md
+++ b/_includes/en/Noteworthy-packages-and-projects.md
@@ -12,4 +12,4 @@ Julia\[Topic\].
 | Web                       | JuliaWeb                                         |
 | Geo-Spatial               | JuliaGeo                                         |
 | Machine Learning          | JuliaML                                          |
-| Super-used Packages       | `DataFrames    # linear/logistic regression`<br>`Distributions # Statistical distributions`<br>`Flux          # Machine learning`<br>`Gadfly        # ggplot2-likeplotting`<br>`LightGraphs   # Network analysis`<br>`TextAnalysis  # NLP` |
+| Super-used Packages       | `DataFrames    # linear/logistic regression`<br>`Distributions # Statistical distributions`<br>`Flux          # Machine learning`<br>`Gadfly        # ggplot2-likeplotting`<br>`Graphs        # Network analysis`<br>`TextAnalysis  # NLP` |

--- a/_includes/es/Noteworthy-packages-and-projects.md
+++ b/_includes/es/Noteworthy-packages-and-projects.md
@@ -12,4 +12,4 @@ Julia\[Topic\].
 | Geo-Spatial               | JuliaGeo                                         |
 | Machine Learning          | JuliaML                                          |
 | Scientific Machine Learning | SciML (formerly DifferentialEquations.jl)      |
-| Super-used Packages       | `DataFrames    # linear/logistic regression`<br>`Distributions # Statistical distributions`<br>`Flux          # Machine learning`<br>`Gadfly        # ggplot2-likeplotting`<br>`LightGraphs   # Network analysis`<br>`TextAnalysis  # NLP` |
+| Super-used Packages       | `DataFrames    # linear/logistic regression`<br>`Distributions # Statistical distributions`<br>`Flux          # Machine learning`<br>`Gadfly        # ggplot2-likeplotting`<br>`Graphs        # Network analysis`<br>`TextAnalysis  # NLP` |

--- a/_includes/fr/Noteworthy-packages-and-projects.md
+++ b/_includes/fr/Noteworthy-packages-and-projects.md
@@ -12,4 +12,4 @@ sous la forme de Julia\[Topic\].
 | *Web*                     | JuliaWeb                                         |
 | Géo-Spatial               | JuliaGeo                                         |
 | *Machine Learning*        | JuliaML                                          |
-| Paquets les plus utilisés | `DataFrames    # régresion linéaire/logistique`<br>`Distributions # Distributions stistiques`<br>`Flux          # Machine learning`<br>`Gadfly        # Tracés graphiques simili-ggplot2`<br>`LightGraphs   # Analyse de réseau`<br>`TextAnalysis  # Traitement de Langage Naturel (NLP)` |
+| Paquets les plus utilisés | `DataFrames    # régresion linéaire/logistique`<br>`Distributions # Distributions stistiques`<br>`Flux          # Machine learning`<br>`Gadfly        # Tracés graphiques simili-ggplot2`<br>`Graphs        # Analyse de réseau`<br>`TextAnalysis  # Traitement de Langage Naturel (NLP)` |

--- a/_includes/ja/Noteworthy-packages-and-projects.md
+++ b/_includes/ja/Noteworthy-packages-and-projects.md
@@ -11,4 +11,4 @@
 | Web                       | JuliaWeb                                         |
 | 地理空間            | JuliaGeo                                         |
 | 機械学習    | JuliaML                                          |
-| 極めてよく用いられるパッケージ    | `DataFrames    # 線形回帰，ロジスティック回帰`<br>`Distributions # 統計学的分布`<br>`Flux          # 機械学習`<br>`Gadfly        # ggplot2に似たグラフ描画`<br>`LightGraphs   # ネットワーク解析`<br>`TextAnalysis  # 自然言語処理` |
+| 極めてよく用いられるパッケージ    | `DataFrames    # 線形回帰，ロジスティック回帰`<br>`Distributions # 統計学的分布`<br>`Flux          # 機械学習`<br>`Gadfly        # ggplot2に似たグラフ描画`<br>`Graphs        # ネットワーク解析`<br>`TextAnalysis  # 自然言語処理` |

--- a/_includes/zh-cn/Noteworthy-packages-and-projects.md
+++ b/_includes/zh-cn/Noteworthy-packages-and-projects.md
@@ -20,5 +20,5 @@
 | [Distributions.jl](https://github.com/JuliaStats/Distributions.jl) |  统计分布 |
 | [Flux.jl](https://github.com/FluxML/Flux.jl)                       |  机器学习 |
 | [Gadfly.jl](https://github.com/GiovineItalia/Gadfly.jl)            |  类 ggplot2 的画图包 |
-| [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl)    |  网络分析 |
+| [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl)              |  网络分析 |
 | [TextAnalysis.jl](https://github.com/JuliaText/TextAnalysis.jl)    |  自然语言处理(NLP) |


### PR DESCRIPTION
The original [LightGraphs.jl](https://github.com/sbromberger/LightGraphs.jl) package has been archived last year and replaced by [Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl) (as mentioned in the [README of Graphs.jl](https://github.com/JuliaGraphs/Graphs.jl#project-status)), so this cheat-sheet should point to the active package.