### PR TITLE
clarify NaN (numeric comparison)

### DIFF
--- a/_includes/en/Operators.md
+++ b/_includes/en/Operators.md
@@ -13,7 +13,7 @@
 | Less than or equal to      | `<=` or `≤`                                     |
 | Greater than or equal to   | `>=` or `≥`                                     |
 | Element-wise operation     | `[1, 2, 3] .+ [1, 2, 3] == [2, 4, 6]`<br>`[1, 2, 3] .* [1, 2, 3] == [1, 4, 9]` |
-| Not a number               | `isnan(NaN)` not(!) `NaN == NaN`                |
+| Not a number               | `[1 NaN] == [1 NaN] --> false` <br>`isequal(NaN, NaN) --> true` |
 | Ternary operator           | `a == b ? "Equal" : "Not equal"`                |
 | Short-circuited AND and OR | `a && b` and `a || b`                           |
 | Object equivalence         | `a === b`                                       |


### PR DESCRIPTION
not(!) part that was present before seemed to be a part of some unexplained syntax with ! sign (which is widely used in Julia), thus not being a clear description. While comparing two NaN's is not something that one would do, I believe comparing two matrices containing NaNs is a more widespread scenario and is important to know and be cautious about.