### PR TITLE
fix docs links

### DIFF
--- a/_includes/br/Resources.md
+++ b/_includes/br/Resources.md
@@ -1,4 +1,4 @@
-- [Official documentation](https://docs.julialang.org/en/latest) .
+- [Official documentation](https://docs.julialang.org/en/v1/) .
 - [Learning Julia](https://julialang.org/learning) page.
 - [Month of Julia](https://github.com/DataWookie/MonthOfJulia)
 - [Community standards](https://julialang.org/community/standards) .

--- a/_includes/en/Resources.md
+++ b/_includes/en/Resources.md
@@ -1,4 +1,4 @@
-- [Official documentation](https://docs.julialang.org/en/latest) .
+- [Official documentation](https://docs.julialang.org/en/v1/) .
 - [Learning Julia](https://julialang.org/learning) page.
 - [Month of Julia](https://github.com/DataWookie/MonthOfJulia)
 - [Community standards](https://julialang.org/community/standards) .

--- a/_includes/es/Resources.md
+++ b/_includes/es/Resources.md
@@ -1,4 +1,4 @@
-- [Official documentation](https://docs.julialang.org/en/latest) .
+- [Official documentation](https://docs.julialang.org/en/v1/) .
 - [Learning Julia](https://julialang.org/learning) page.
 - [Month of Julia](https://github.com/DataWookie/MonthOfJulia)
 - [Community standards](https://julialang.org/community/standards) .

--- a/_includes/fr/Resources.md
+++ b/_includes/fr/Resources.md
@@ -1,4 +1,4 @@
-- [Documentation officielle](https://docs.julialang.org/en/latest) .
+- [Documentation officielle](https://docs.julialang.org/en/v1/) .
 - Page [Apprendre Julia](https://julialang.org/learning).
 - [Mois de Julia](https://github.com/DataWookie/MonthOfJulia)
 - [Standards communautaires](https://julialang.org/community/standards) .

--- a/_includes/ja/Resources.md
+++ b/_includes/ja/Resources.md
@@ -1,4 +1,4 @@
-- [Official documentation](https://docs.julialang.org/en/latest) .
+- [Official documentation](https://docs.julialang.org/en/v1/) .
 - [Learning Julia](https://julialang.org/learning) page.
 - [Month of Julia](https://github.com/DataWookie/MonthOfJulia)
 - [Community standards](https://julialang.org/community/standards) .

--- a/_includes/zh-cn/Resources.md
+++ b/_includes/zh-cn/Resources.md
@@ -4,7 +4,7 @@
 
 ## 英文资源
 
-- [Julia 官方文档](https://docs.julialang.org/en/latest)
+- [Julia 官方文档](https://docs.julialang.org/en/v1/)
 - [学习 Julia 的在线资源](https://julialang.org/learning)
 - [Julia 之月](https://github.com/DataWookie/MonthOfJulia)
 - [社区准则](https://julialang.org/community/standards) 


### PR DESCRIPTION
https://docs.julialang.org/en/latest doesn't seem to work anymore, but https://docs.julialang.org/en/v1 does. I did not update the `cn` links because there `latest` does work and provides newer docs than `v1`.